### PR TITLE
Add explicit permissions to GitHub Actions workflows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,9 @@ name: Build and Release (Manual Run) v1.3
 on:
   workflow_dispatch: # This event allows manual triggering
 
+permissions:
+  contents: write
+
 env:
   THIRD_PARTY_GIT_AUTHOR_EMAIL: opensource+bot@newrelic.com
   THIRD_PARTY_GIT_AUTHOR_NAME: nr-opensource-bot

--- a/.github/workflows/repolinter.yml
+++ b/.github/workflows/repolinter.yml
@@ -8,6 +8,10 @@ name: Repolinter Action
 # filtered in the "Test Default Branch" step.
 on: [push, workflow_dispatch]
 
+permissions:
+  contents: read
+  issues: write
+
 jobs:
   repolint:
     name: Run Repolinter


### PR DESCRIPTION
## Summary
- Adds explicit `permissions` block to `release.yml` (`contents: write`) and `repolinter.yml` (`contents: read`, `issues: write`)
- Resolves CodeQL code-scanning alerts [#5](https://github.com/newrelic/newrelic-java-vertx-extensions/security/code-scanning/5) and [#6](https://github.com/newrelic/newrelic-java-vertx-extensions/security/code-scanning/6) for `actions/missing-workflow-permissions`
- Applies least-privilege principle per GitHub's security hardening recommendations
